### PR TITLE
Addition of custom popup to the learning path tree

### DIFF
--- a/client/src/components/UnitPopup.jsx
+++ b/client/src/components/UnitPopup.jsx
@@ -1,35 +1,93 @@
 import React from 'react';
-import { Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Button } from "@mui/material";
+import { Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Button, IconButton } from "@mui/material";
 
 const UnitPopup = ({ isOpen, node, onClose, onInsert, onAppend, onEdit, onDelete, isAdmin }) => {
     const handleEnterLesson = () => {
         window.location.href = `http://localhost:3000/${node.type}/${node.id}`;
     };
 
+    const titleStyle = {
+        color: '#1a73e8', // Blue color
+        fontSize: '24px', 
+        fontWeight: 'bold',
+        textAlign: 'center',
+        margin: '20px 0'
+    };
+
+    const contentStyle = {
+        fontSize: '18px',
+        textAlign: 'center',
+        marginBottom: '20px'
+    };
+
+    const buttonStyle = {
+        margin: '10px',
+        padding: '10px 20px',
+        fontSize: '16px',
+        borderRadius: '5px'
+    };
+
+    const buttonPrimary = {
+        ...buttonStyle,
+        backgroundColor: '#1a73e8',
+        color: '#fff'
+    };
+
+    const buttonSecondary = {
+        ...buttonStyle,
+        backgroundColor: '#f1f3f4',
+        color: '#000'
+    };
+
+    const buttonGreen = {
+        ...buttonStyle,
+        backgroundColor: '#34a853',
+        color: '#fff'
+    };
+
+    const buttonRed = {
+        ...buttonStyle,
+        backgroundColor: '#ea4335',
+        color: '#fff'
+    };
+
+    const buttonEdit = {
+        ...buttonStyle,
+        backgroundColor: '#646464',
+        color: '#fff'
+    };
+
+    const dialogTitleStyle = {
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        paddingRight: '24px',
+        paddingLeft: '24px'
+    };
+
     return (
         <Dialog open={isOpen} onClose={onClose}>
-            <DialogTitle>
-                {node && node.title}
+            <DialogTitle style={dialogTitleStyle}>
+                <span style={titleStyle}>{node && node.title}</span>
             </DialogTitle>
             <DialogContent>
-                <DialogContentText>
+                <DialogContentText style={contentStyle}>
                     {node && node.content}
-                </DialogContentText> 
+                </DialogContentText>
             </DialogContent>
-            <DialogActions>
-                <Button onClick={onClose} color="primary">Close</Button>
-                <Button onClick={handleEnterLesson} color="primary">Go to {node && node.type}</Button>
+            <DialogActions style={{ justifyContent: 'center' }}>
+                <Button onClick={onClose} style={buttonSecondary}>Back</Button>
+                <Button onClick={handleEnterLesson} style={buttonPrimary}>Enter</Button>
             </DialogActions>
             {
                 isAdmin &&
-                <DialogActions>
-                    <Button onClick={onInsert} color="primary">Insert child</Button>
-                    <Button onClick={onAppend} color="primary">Append child</Button>
-                    <Button onClick={onEdit} color="primary">Edit</Button>
-                    <Button onClick={onDelete} color="primary">Delete</Button>
+                <DialogActions style={{ justifyContent: 'center' }}>
+                    <Button onClick={onInsert} style={buttonGreen}>Insert Child</Button>
+                    <Button onClick={onAppend} style={buttonGreen}>Append Child</Button>
+                    <Button onClick={onEdit} style={buttonEdit}>Edit</Button>
+                    <Button onClick={onDelete} style={buttonRed}>Delete</Button>
                 </DialogActions>
             }
-            
         </Dialog>
     );
 };

--- a/client/src/components/UnitPopup.jsx
+++ b/client/src/components/UnitPopup.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Button } from "@mui/material";
+
+const UnitPopup = ({ isOpen, node, onClose }) => {
+    const handleEnterLesson = () => {
+        window.location.href = `http://localhost:3000/${node.type}/${node.key}`;
+    };
+
+    return (
+        <Dialog open={isOpen} onClose={onClose}>
+            <DialogTitle>Node Selected</DialogTitle>
+            <DialogContent>
+                <DialogContentText>
+                    {node && `You selected a ${node.type} node with key: ${node.key}`}
+                </DialogContentText>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={onClose} color="primary">
+                    Close
+                </Button>
+                <Button onClick={handleEnterLesson
+            
+                } color="primary">
+                    Go to {node && node.type}
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default UnitPopup;

--- a/client/src/components/UnitPopup.jsx
+++ b/client/src/components/UnitPopup.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Button, IconButton } from "@mui/material";
+import CloseIcon from '@mui/icons-material/Close';
 
 const UnitPopup = ({ isOpen, node, onClose, onInsert, onAppend, onEdit, onDelete, isAdmin }) => {
     const handleEnterLesson = () => {
@@ -69,6 +70,9 @@ const UnitPopup = ({ isOpen, node, onClose, onInsert, onAppend, onEdit, onDelete
         <Dialog open={isOpen} onClose={onClose}>
             <DialogTitle style={dialogTitleStyle}>
                 <span style={titleStyle}>{node && node.title}</span>
+                <IconButton edge="end" color="inherit" onClick={onClose} aria-label="close" style={{margin: '12px'}}>
+                    <CloseIcon />
+                </IconButton>
             </DialogTitle>
             <DialogContent>
                 <DialogContentText style={contentStyle}>
@@ -76,7 +80,7 @@ const UnitPopup = ({ isOpen, node, onClose, onInsert, onAppend, onEdit, onDelete
                 </DialogContentText>
             </DialogContent>
             <DialogActions style={{ justifyContent: 'center' }}>
-                <Button onClick={onClose} style={buttonSecondary}>Back</Button>
+                {/* <Button onClick={onClose} style={buttonSecondary}>Back</Button> */}
                 <Button onClick={handleEnterLesson} style={buttonPrimary}>Enter</Button>
             </DialogActions>
             {

--- a/client/src/components/UnitPopup.jsx
+++ b/client/src/components/UnitPopup.jsx
@@ -3,16 +3,16 @@ import { Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, B
 
 const UnitPopup = ({ isOpen, node, onClose }) => {
     const handleEnterLesson = () => {
-        window.location.href = `http://localhost:3000/${node.type}/${node.key}`;
+        window.location.href = `http://localhost:3000/${node.type}/${node.id}`;
     };
 
     return (
         <Dialog open={isOpen} onClose={onClose}>
-            <DialogTitle>Node Selected</DialogTitle>
+            <DialogTitle>Node Selected {node && node.title}</DialogTitle>
             <DialogContent>
                 <DialogContentText>
-                    {node && `You selected a ${node.type} node with key: ${node.key}`}
-                </DialogContentText>
+                    {node && `You selected a ${node.type} nodess with id: ${node.id}`}
+                </DialogContentText> 
             </DialogContent>
             <DialogActions>
                 <Button onClick={onClose} color="primary">

--- a/client/src/components/UnitPopup.jsx
+++ b/client/src/components/UnitPopup.jsx
@@ -1,29 +1,35 @@
 import React from 'react';
 import { Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Button } from "@mui/material";
 
-const UnitPopup = ({ isOpen, node, onClose }) => {
+const UnitPopup = ({ isOpen, node, onClose, onInsert, onAppend, onEdit, onDelete, isAdmin }) => {
     const handleEnterLesson = () => {
         window.location.href = `http://localhost:3000/${node.type}/${node.id}`;
     };
 
     return (
         <Dialog open={isOpen} onClose={onClose}>
-            <DialogTitle>Node Selected {node && node.title}</DialogTitle>
+            <DialogTitle>
+                {node && node.title}
+            </DialogTitle>
             <DialogContent>
                 <DialogContentText>
-                    {node && `You selected a ${node.type} nodess with id: ${node.id}`}
+                    {node && node.content}
                 </DialogContentText> 
             </DialogContent>
             <DialogActions>
-                <Button onClick={onClose} color="primary">
-                    Close
-                </Button>
-                <Button onClick={handleEnterLesson
-            
-                } color="primary">
-                    Go to {node && node.type}
-                </Button>
+                <Button onClick={onClose} color="primary">Close</Button>
+                <Button onClick={handleEnterLesson} color="primary">Go to {node && node.type}</Button>
             </DialogActions>
+            {
+                isAdmin &&
+                <DialogActions>
+                    <Button onClick={onInsert} color="primary">Insert child</Button>
+                    <Button onClick={onAppend} color="primary">Append child</Button>
+                    <Button onClick={onEdit} color="primary">Edit</Button>
+                    <Button onClick={onDelete} color="primary">Delete</Button>
+                </DialogActions>
+            }
+            
         </Dialog>
     );
 };

--- a/client/src/components/UnitPopup.jsx
+++ b/client/src/components/UnitPopup.jsx
@@ -8,7 +8,7 @@ const UnitPopup = ({ isOpen, node, onClose, onInsert, onAppend, onEdit, onDelete
     };
 
     const titleStyle = {
-        color: '#1a73e8', // Blue color
+        color: '#3ca3ee', // Blue color
         fontSize: '24px', 
         fontWeight: 'bold',
         textAlign: 'center',
@@ -30,7 +30,7 @@ const UnitPopup = ({ isOpen, node, onClose, onInsert, onAppend, onEdit, onDelete
 
     const buttonPrimary = {
         ...buttonStyle,
-        backgroundColor: '#1a73e8',
+        backgroundColor: '#3ca3ee',
         color: '#fff'
     };
 

--- a/client/src/pages/LearningPathPage.jsx
+++ b/client/src/pages/LearningPathPage.jsx
@@ -92,70 +92,42 @@ const LearningPathPage = () => {
         // ID of lesson is stored in node.key
         console.log("Node with key '" + node.key + "' selected!");
 
-        // TODO: Popup of some kind? Either find a way to use the tree module or our use our own (Eg use MUI component)
+        // Retrieve current node details for the popup
+        var currentNode = findSelectedNode(learningPathData, node.key);
 
-        // Function to recursively find lessons, videos, and quizzes
-        const findLessonTypes = (data) => {
-            const lessons = [];
-            const videos = [];
-            const quizzes = [];
-
-            if (Array.isArray(data)) {
-            for (let item of data) {
-                const { lessons: itemLessons, videos: itemVideos, quizzes: itemQuizzes } = findLessonTypes(item);
-                lessons.push(...itemLessons);
-                videos.push(...itemVideos);
-                quizzes.push(...itemQuizzes);
-            }
-            // Checks what the data type is, appends to appropriate array
-            } else if (typeof data === 'object' && data !== null) {
-            if (data.type === 'lesson') {
-                lessons.push(data.id);
-            } else if (data.type === 'video') {
-                videos.push(data.id);
-            } else if (data.type === 'quiz') {
-                quizzes.push(data.id);
-            }
-
-            if (data.children) {
-                const { lessons: childLessons, videos: childVideos, quizzes: childQuizzes } = findLessonTypes(data.children);
-                lessons.push(...childLessons);
-                videos.push(...childVideos);
-                quizzes.push(...childQuizzes);
-            }
-            }
-
-            return { lessons, videos, quizzes };
-        };
-
-        // Find all lesson, video, and quiz ids in the learning path data
-        const { lessons, videos, quizzes } = findLessonTypes(learningPathData);
-        // console.log('Lesson IDs:', lessons);
-        // console.log('Video IDs:', videos);
-        // console.log('Quiz IDs:', quizzes);
-
-        // Checks with node key is in the array
-        var output;
-        if (lessons.includes(node.key)) {
-            output = "lesson";
-        } else if (quizzes.includes(node.key)) {
-            output = "quiz";
-        }
-        else {output = "video";} // NOTE: BUG IDENTIFIED: there was a bug where the video for recognising AI in real life was not found to be video. Instead output is undefined. Changed this for the demo.
-
-        // console.log("http://localhost:3000/" + output + "/:" + node.key)
-
-        setSelectedNode({ ...node, type: output });
+        // Store current node for popup
+        setSelectedNode(currentNode);
         setIsPopupOpen(true);
 
-        // window.location.href =
-        //     "http://localhost:3000/" + output + "/" + node.key;
+        // window.location.href = "http://localhost:3000/" + currentNode.type + "/" + node.id;
     };
 
     const handlePopupClose = () => {
         setIsPopupOpen(false);
         setSelectedNode(null);
     };
+
+   // Recursive function to find the details of the selected node
+    const findSelectedNode = (tree, id) => {
+        for (const node of tree) {
+            if (node.id === id) {
+                return {
+                    id: node.id,
+                    type: node.type,
+                    title: node.title,
+                    content: node.tooltip ? node.tooltip.content : null
+                };
+            }
+            else if (node.children && node.children.length > 0) {
+                const result = findSelectedNode(node.children, id);
+                if (result) {
+                    return result;
+                }
+            }
+        }
+        return null; // Return null if the id is not found
+    };
+    
 
     return (
         <div style={{ backgroundColor: "#3CA3EE" }}>

--- a/client/src/pages/LearningPathPage.jsx
+++ b/client/src/pages/LearningPathPage.jsx
@@ -102,11 +102,6 @@ const LearningPathPage = () => {
         // window.location.href = "http://localhost:3000/" + currentNode.type + "/" + node.id;
     };
 
-    const handlePopupClose = () => {
-        setIsPopupOpen(false);
-        setSelectedNode(null);
-    };
-
    // Recursive function to find the details of the selected node
     const findSelectedNode = (tree, id) => {
         for (const node of tree) {
@@ -126,6 +121,28 @@ const LearningPathPage = () => {
             }
         }
         return null; // Return null if the id is not found
+    };
+
+    const handlePopupClose = () => {
+        // Close the popup
+        setIsPopupOpen(false);
+        setSelectedNode(null);
+    };
+
+    const handlePopupInsert = () => {
+        // TODO: Handle an insert of child. A new node should be inserted between this node and its children
+    };
+
+    const handlePopupAppend = () => {
+        // TODO: Handle an append of a child. A new node should be added to this nodes's children
+    };
+
+    const handlePopupEdit = () => {
+        // TODO: Handle an editing of a node. Navigate to a new page
+    };
+
+    const handlePopupDelete = () => {
+        // TODO: Handle a delelete of a node. 
     };
     
 
@@ -153,10 +170,16 @@ const LearningPathPage = () => {
                 </SkillProvider>
             )}
         
+            {/* { isOpen, node, onClose, onInsert, onAppend, onEdit, onDelete, isAdmin } */}
             <UnitPopup 
                 isOpen={isModalOpen} 
                 node={selectedNode} 
                 onClose={handlePopupClose} 
+                onInsert={handlePopupInsert} 
+                onAppend={handlePopupAppend} 
+                onEdit={handlePopupEdit} 
+                onDelete={handlePopupDelete} 
+                isAdmin={true} // True for testing, change later
             />
 
         </div>

--- a/client/src/pages/LearningPathPage.jsx
+++ b/client/src/pages/LearningPathPage.jsx
@@ -16,6 +16,15 @@ import "../assets/styles/App.css";
 import { Box } from "@mui/material";
 import UnitPopup from "../components/UnitPopup.jsx";
 
+// Coloured background theme
+const theme = {
+    border: "transparent",
+    borderRadius: "8px",
+    treeBackgroundColor: "#transparent", // Tree background colour //Note it is set to a broken value which makes the popup black
+    nodeBackgroundColor: "#646464", // Locked node colour
+    nodeActiveBackgroundColor: "#FDC700", // Unlocked node colour
+    nodeHoverBorderColor: `#FFFFFF`, // Node border colour
+};
 
 const LearningPathPage = () => {
     const { getData } = useApi();
@@ -72,16 +81,6 @@ const LearningPathPage = () => {
         return item;
     }
 
-    // Coloured background theme
-    const theme = {
-        border: "transparent",
-        borderRadius: "8px",
-        treeBackgroundColor: "#transparent", // Tree background colour //Note it is set to a broken value which makes the popup black
-        nodeBackgroundColor: "#646464", // Locked node colour
-        nodeActiveBackgroundColor: "#FDC700", // Unlocked node colour
-        nodeHoverBorderColor: `#FFFFFF`, // Node border colour
-    };
-
     // Function for handling when a lesson is clicked. Retrieve the details of the node and display a popup.
     const handleNodeSelect = (node) => {
         // ID of lesson is stored in node.key
@@ -131,7 +130,12 @@ const LearningPathPage = () => {
     };
 
     const handlePopupEdit = () => {
-        // TODO: Handle an editing of a node. Navigate to the lesson edit page
+        // Handle an editing of a node. Navigate to the edit page
+        //window.location.href = `http://localhost:3000/${selectedNode.id}/edit`;
+
+        // Redirect based on the lesson type. Either /editLesson, /editVideo or /editQuiz
+        const nodeType = selectedNode.type.charAt(0).toUpperCase() + selectedNode.type.slice(1); // Make first letter uppercase
+        window.location.href = `http://localhost:3000/${selectedNode.id}/edit${nodeType}`;
     };
 
     const handlePopupDelete = () => {
@@ -163,7 +167,6 @@ const LearningPathPage = () => {
                 </SkillProvider>
             )}
         
-            {/* { isOpen, node, onClose, onInsert, onAppend, onEdit, onDelete, isAdmin } */}
             <UnitPopup 
                 isOpen={isModalOpen} 
                 node={selectedNode} 
@@ -172,7 +175,7 @@ const LearningPathPage = () => {
                 onAppend={handlePopupAppend} 
                 onEdit={handlePopupEdit} 
                 onDelete={handlePopupDelete} 
-                isAdmin={true} // True for testing, change later
+                isAdmin={true} // Assume current user is admin. TODO: Check the current user's type
             />
 
         </div>

--- a/client/src/pages/LearningPathPage.jsx
+++ b/client/src/pages/LearningPathPage.jsx
@@ -17,7 +17,10 @@ import { useApi } from '../context/ApiProvider';
 // Import hard-coded learning path data
 import { savedProgressData } from "./learningPathData.js";
 import "../assets/styles/App.css";
-import { Box } from "@mui/material";
+// import { Box } from "@mui/material";
+import { Box, Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Button } from "@mui/material";
+import UnitPopup from "../components/UnitPopup.jsx";
+
 
 const LearningPathPage = () => {
     const { getData } = useApi();
@@ -25,6 +28,9 @@ const LearningPathPage = () => {
     const [learningPathData, setLearningPathData] = useState([]);
     const [learningPathTitle, setLearningPathTitle] = useState([]); // get the title of the learning path unit
     const [isUnitLoading, setIsUnitLoading] = useState(true); // set loading spinner
+
+    const [selectedNode, setSelectedNode] = useState(null); // State for the selected node
+    const [isModalOpen, setIsPopupOpen] = useState(false); // State for popup open/close
     
     const { unitId } = useParams();
 
@@ -139,8 +145,16 @@ const LearningPathPage = () => {
 
         // console.log("http://localhost:3000/" + output + "/:" + node.key)
 
-        window.location.href =
-            "http://localhost:3000/" + output + "/" + node.key;
+        setSelectedNode({ ...node, type: output });
+        setIsPopupOpen(true);
+
+        // window.location.href =
+        //     "http://localhost:3000/" + output + "/" + node.key;
+    };
+
+    const handlePopupClose = () => {
+        setIsPopupOpen(false);
+        setSelectedNode(null);
     };
 
     return (
@@ -166,6 +180,13 @@ const LearningPathPage = () => {
                     </SkillTreeGroup>
                 </SkillProvider>
             )}
+        
+            <UnitPopup 
+                isOpen={isModalOpen} 
+                node={selectedNode} 
+                onClose={handlePopupClose} 
+            />
+
         </div>
     );
 };

--- a/client/src/pages/LearningPathPage.jsx
+++ b/client/src/pages/LearningPathPage.jsx
@@ -9,16 +9,11 @@ import {
     SkillTreeGroup,
     SkillTree,
     SkillProvider,
-    SkillType,
-    SkillGroupDataType,
 } from "beautiful-skill-tree";
 import { useApi } from '../context/ApiProvider';
 
-// Import hard-coded learning path data
-import { savedProgressData } from "./learningPathData.js";
 import "../assets/styles/App.css";
-// import { Box } from "@mui/material";
-import { Box, Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Button } from "@mui/material";
+import { Box } from "@mui/material";
 import UnitPopup from "../components/UnitPopup.jsx";
 
 
@@ -87,10 +82,10 @@ const LearningPathPage = () => {
         nodeHoverBorderColor: `#FFFFFF`, // Node border colour
     };
 
-    // Function for handling when a lesson is clicked. Navigate to the corresponding lesson page
+    // Function for handling when a lesson is clicked. Retrieve the details of the node and display a popup.
     const handleNodeSelect = (node) => {
         // ID of lesson is stored in node.key
-        console.log("Node with key '" + node.key + "' selected!");
+        // console.log("Node with key '" + node.key + "' selected!");
 
         // Retrieve current node details for the popup
         var currentNode = findSelectedNode(learningPathData, node.key);
@@ -98,8 +93,6 @@ const LearningPathPage = () => {
         // Store current node for popup
         setSelectedNode(currentNode);
         setIsPopupOpen(true);
-
-        // window.location.href = "http://localhost:3000/" + currentNode.type + "/" + node.id;
     };
 
    // Recursive function to find the details of the selected node
@@ -138,11 +131,11 @@ const LearningPathPage = () => {
     };
 
     const handlePopupEdit = () => {
-        // TODO: Handle an editing of a node. Navigate to a new page
+        // TODO: Handle an editing of a node. Navigate to the lesson edit page
     };
 
     const handlePopupDelete = () => {
-        // TODO: Handle a delelete of a node. 
+        // TODO: Handle a delete of a node. 
     };
     
 


### PR DESCRIPTION
Changes:
1. New popup window in the front-end for when a user clicks on a node in the learning path tree. This will allow us to modify the tree structure. Buttons include:
- The "enter" button takes the user to the lesson, video or quiz selected.
- The "edit" button takes the user to http://localhost:3000/lessonId/edit{lessonType} to edit its content.
- The remaining buttons are placeholders (to append, insert and delete nodes).
2. Refactored a recursive function which simplifies the process of retrieving data for the current node selected. This is used to populate the UnitPopup component.