### PR TITLE
implement delete node

### DIFF
--- a/client/src/pages/LearningPathPage.jsx
+++ b/client/src/pages/LearningPathPage.jsx
@@ -180,8 +180,34 @@ const LearningPathPage = () => {
         window.location.href = `http://localhost:3000/${selectedNode.id}/edit${nodeType}`;
     };
 
-    const handlePopupDelete = () => {
-        // TODO: Handle a delete of a node. 
+    
+    const handlePopupDelete = async () => {
+        if (!selectedNode) return;
+    
+        // confirming deletion of node using window
+        const isConfirmed = window.confirm('Are you sure you want to delete this node? Its children will be reappended to the parent node. This action cannot be undone.');
+        
+        if (isConfirmed) {
+            try {
+                const response = await postData(`api/units/${unitId}/delete`, { 
+                    unitId, 
+                    nodeId: selectedNode.id 
+                });
+                
+                console.log(response);
+                
+                // close the popup
+                setIsPopupOpen(false);
+                setSelectedNode(null);
+    
+                // refresh the page to show updated structure
+                navigate(0);
+                
+            } catch (error) {
+                console.error('Error deleting node:', error);
+                alert("An error occurred while deleting the node. Please try again.");
+            }
+        }
     };
     
 

--- a/server/routes/unitRoutes.js
+++ b/server/routes/unitRoutes.js
@@ -1,10 +1,11 @@
 const express = require('express')
 const router = express.Router()
-const { getUnit, getUnits, appendNode, insertNode } = require('../controllers/unitController')
+const { getUnit, getUnits, appendNode, insertNode, deleteNode } = require('../controllers/unitController')
 
 router.route('/').get(getUnits)
 router.route('/:id').get(getUnit)
 router.post('/:id/append', appendNode);
 router.post('/:id/insert', insertNode);
+router.post('/:id/delete', deleteNode);
 
 module.exports = router


### PR DESCRIPTION
Implementation of delete node in learning path.

Delete works by reappending children node to parent node. Not sure if we want to keep this. I can only think of adding another option to delete all children node, or just that one node. 

Currently have a window set to double confirm whether the user wants to delete the node or not. Doesn't look that pretty tbh, can probably rework.

Throws an error when trying to delete the root node of the unit. Will probably have to rework this? 