### PR TITLE
options for adding nodes to learning path

### DIFF
--- a/client/src/components/LessonTypesPopup.jsx
+++ b/client/src/components/LessonTypesPopup.jsx
@@ -46,7 +46,7 @@ const LessonTypesPopup = ({ isOpen, onClose, onClick }) => {
             variant="h6"
             sx={{ marginBottom: "15px", fontWeight: "bold", color: "#3CA3EE" }}
           >
-            Create New Lesson
+            Create New Module
           </Typography>
           <Grid container spacing={2} justifyContent="center">
             <Grid item xs={12} sm={4}>
@@ -57,11 +57,13 @@ const LessonTypesPopup = ({ isOpen, onClose, onClick }) => {
                   onClick("lesson");
                 }} // hardcoded for testing
                 sx={{
-                  color: "#2196F3",
-                  borderColor: "#2196F3",
+                  color: "#fff",
+                  backgroundColor: '#3ca3ee',
+                  borderColor: "#3ca3ee",
                   marginBottom: "10px",
+                  borderRadius: '7px',
                   ":hover": {
-                    backgroundColor: "#f0f0f0",
+                    backgroundColor: "#2196F3",
                     borderColor: "#2196F3",
                   },
                 }}
@@ -75,11 +77,13 @@ const LessonTypesPopup = ({ isOpen, onClose, onClick }) => {
                 variant="outlined"
                 onClick={() => onClick("video")}
                 sx={{
-                  color: "#2196F3",
-                  borderColor: "#2196F3",
+                  color: "#fff",
+                  backgroundColor: '#3ca3ee',
+                  borderColor: "#3ca3ee",
                   marginBottom: "10px",
+                  borderRadius: '7px',
                   ":hover": {
-                    backgroundColor: "#f0f0f0",
+                    backgroundColor: "#2196F3",
                     borderColor: "#2196F3",
                   },
                 }}
@@ -93,10 +97,13 @@ const LessonTypesPopup = ({ isOpen, onClose, onClick }) => {
                 variant="outlined"
                 onClick={handleQuizClick}
                 sx={{
-                  color: "#2196F3",
-                  borderColor: "#2196F3",
+                  color: "#fff",
+                  backgroundColor: '#3ca3ee',
+                  borderColor: "#3ca3ee",
+                  marginBottom: "10px",
+                  borderRadius: '7px',
                   ":hover": {
-                    backgroundColor: "#f0f0f0",
+                    backgroundColor: "#2196F3",
                     borderColor: "#2196F3",
                   },
                 }}

--- a/client/src/components/LessonTypesPopup.jsx
+++ b/client/src/components/LessonTypesPopup.jsx
@@ -1,0 +1,145 @@
+import React, { useState } from "react";
+import {
+  Box,
+  Button,
+  Typography,
+  MenuItem,
+  Menu,
+  Grid,
+  Modal,
+} from "@mui/material";
+import { useNavigate } from "react-router-dom";
+
+const LessonTypesPopup = ({ isOpen, onClose, onClick }) => {
+  const [quizAnchorEl, setQuizAnchorEl] = useState(null);
+  const navigate = useNavigate();
+
+  const handleQuizClick = (event) => {
+    setQuizAnchorEl(event.currentTarget);
+  };
+
+  const handleQuizClose = () => {
+    setQuizAnchorEl(null);
+  };
+
+  return (
+    <>
+      <Modal open={isOpen} onClose={onClose}>
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "center",
+            alignItems: "center",
+            backgroundColor: "white",
+            padding: "20px",
+            borderRadius: "12px",
+            boxShadow: 24,
+            width: "300px",
+            textAlign: "center",
+            margin: "auto",
+            marginTop: "10%",
+            outline: "none",
+          }}
+        >
+          <Typography
+            variant="h6"
+            sx={{ marginBottom: "15px", fontWeight: "bold", color: "#3CA3EE" }}
+          >
+            Create New Lesson
+          </Typography>
+          <Grid container spacing={2} justifyContent="center">
+            <Grid item xs={12} sm={4}>
+              <Button
+                fullWidth
+                variant="outlined"
+                onClick={() => {
+                  onClick("lesson");
+                }} // hardcoded for testing
+                sx={{
+                  color: "#2196F3",
+                  borderColor: "#2196F3",
+                  marginBottom: "10px",
+                  ":hover": {
+                    backgroundColor: "#f0f0f0",
+                    borderColor: "#2196F3",
+                  },
+                }}
+              >
+                Reading
+              </Button>
+            </Grid>
+            <Grid item xs={12} sm={4}>
+              <Button
+                fullWidth
+                variant="outlined"
+                onClick={() => onClick("video")}
+                sx={{
+                  color: "#2196F3",
+                  borderColor: "#2196F3",
+                  marginBottom: "10px",
+                  ":hover": {
+                    backgroundColor: "#f0f0f0",
+                    borderColor: "#2196F3",
+                  },
+                }}
+              >
+                Video
+              </Button>
+            </Grid>
+            <Grid item xs={12} sm={4}>
+              <Button
+                fullWidth
+                variant="outlined"
+                onClick={handleQuizClick}
+                sx={{
+                  color: "#2196F3",
+                  borderColor: "#2196F3",
+                  ":hover": {
+                    backgroundColor: "#f0f0f0",
+                    borderColor: "#2196F3",
+                  },
+                }}
+              >
+                Quiz
+              </Button>
+            </Grid>
+          </Grid>
+          <Menu
+            anchorEl={quizAnchorEl}
+            open={Boolean(quizAnchorEl)}
+            onClose={handleQuizClose}
+            sx={{ mt: 1 }}
+          >
+            {[
+              "Multiple Choice",
+              "Reorder",
+              "Image",
+              "True False",
+              "Short Answer",
+              "Drag And Drop",
+            ].map((quizType, index) => (
+              <MenuItem
+                key={index}
+                onClick={() => {
+                  onClick("quiz", quizType.replace(" ", ""));
+                }}
+                sx={{
+                  ":hover": {
+                    backgroundColor: "#3CA3EE",
+                    color: "white",
+                  },
+                }}
+              >
+                {quizType}
+              </MenuItem>
+            ))}
+          </Menu>
+        </Box>
+      </Modal>
+    </>
+  );
+};
+
+export default LessonTypesPopup;
+

--- a/client/src/pages/LearningPathPage.jsx
+++ b/client/src/pages/LearningPathPage.jsx
@@ -15,6 +15,7 @@ import { useApi } from '../context/ApiProvider';
 import "../assets/styles/App.css";
 import { Box } from "@mui/material";
 import UnitPopup from "../components/UnitPopup.jsx";
+import LessonTypesPopup from "../components/LessonTypesPopup.jsx";
 
 // Coloured background theme
 const theme = {
@@ -36,6 +37,8 @@ const LearningPathPage = () => {
 
     const [selectedNode, setSelectedNode] = useState(null); // State for the selected node
     const [isModalOpen, setIsPopupOpen] = useState(false); // State for popup open/close
+    const [isInsertLessonTypeModalOpen, setIsInsertLessonTypeModalOpen] = useState(false);
+    const [isAppendLessonTypeModalOpen, setIsAppendLessonTypeModalOpen] = useState(false);
     
     const { unitId } = useParams();
 
@@ -122,13 +125,23 @@ const LearningPathPage = () => {
         setSelectedNode(null);
     };
 
-    const handlePopupInsert = async () => {
+    const handleLessonTypePopupClose = () => {
+        setIsInsertLessonTypeModalOpen(false);
+        setIsAppendLessonTypeModalOpen(false);
+    };
+
+    const handleInsertNewLessonType = () => {
+        setIsInsertLessonTypeModalOpen(true);
+    };
+
+    const handleAppendNewLessonType = () => {
+        setIsAppendLessonTypeModalOpen(true);
+    };
+
+    const handlePopupInsert = async (inputType, inputSubType) => {
         // Handle an insert of child. A new node should be inserted between this node and its children
         const targetNodeId = selectedNode.id;
-        
-        const inputType = 'lesson' // Possible learning modules: 'lesson', 'video' or 'quiz'
-        const inputSubType = 'MultipleChoice' // Possible quiz types: MultipleChoice, ImageQuiz, ShortAnswer, Reorder, DragAndDrop
-        
+                
         // New node object with placeholder values
         const newNode = {
             icon: `${inputType}Icon`,
@@ -149,13 +162,10 @@ const LearningPathPage = () => {
         }
     };
 
-    async function handlePopupAppend() {
+    async function handlePopupAppend(inputType, inputSubType) {
         // Handle an append of a child. A new node should be added to this nodes's children
         const targetNodeId = selectedNode.id;
-        
-        const inputType = 'lesson' // Possible learning modules: 'lesson', 'video' or 'quiz'
-        const inputSubType = 'TrueFalse' // Possible quiz types: MultipleChoice, ImageQuiz, ShortAnswer, Reorder, DragAndDrop, TrueFalse
-        
+                
         // New node object with placeholder values
         const newNode = {
             icon: `${inputType}Icon`,
@@ -240,13 +250,22 @@ const LearningPathPage = () => {
                 isOpen={isModalOpen} 
                 node={selectedNode} 
                 onClose={handlePopupClose} 
-                onInsert={handlePopupInsert} 
-                onAppend={handlePopupAppend} 
+                onInsert={handleInsertNewLessonType} 
+                onAppend={handleAppendNewLessonType}
                 onEdit={handlePopupEdit} 
                 onDelete={handlePopupDelete} 
                 isAdmin={true} // Assume current user is admin. TODO: Check the current user's type
             />
-
+            <LessonTypesPopup
+                isOpen={isInsertLessonTypeModalOpen}
+                onClose={handleLessonTypePopupClose}
+                onClick={handlePopupInsert}
+            />
+            <LessonTypesPopup
+                isOpen={isAppendLessonTypeModalOpen}
+                onClose={handleLessonTypePopupClose}
+                onClick={handlePopupAppend}
+            />
         </div>
     );
 };


### PR DESCRIPTION
When user presses 'Append' or 'Insert' options to add to the learning path, they get a popup to choose which type of content they want to add. Pressing on 'quiz' provides subType options.

<img width="412" alt="image" src="https://github.com/user-attachments/assets/4a0069d9-3af3-42eb-82b2-1e0cddea4986">
